### PR TITLE
Add IGNORABLE_REPORT_KEYS config

### DIFF
--- a/src/audit_analyser.py
+++ b/src/audit_analyser.py
@@ -38,4 +38,8 @@ class AuditAnalyser:
             if audit.type.startswith(audit_key):
                 return audit_analyser.analyse(audit)
 
-        raise UnsupportedAuditException(audit.type)
+        if audit.type in config.get_ignorable_report_keys():
+            logger.warning(f"Ignoring unsupported key '{audit.type}' as it is present in ignorable_report_keys config")
+            return set()
+        else:
+            raise UnsupportedAuditException(audit.type)

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -73,6 +73,9 @@ class Config:
     def get_password_policy_audit_report_key(self) -> str:
         return self._get_env("PASSWORD_POLICY_AUDIT_REPORT_KEY")
 
+    def get_ignorable_report_keys(self) -> List[str]:
+        return self._get_env("IGNORABLE_REPORT_KEYS").split(",")
+
     def get_slack_api_url(self) -> str:
         return self._get_env("SLACK_API_URL")
 

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -30,6 +30,7 @@ from src.slack_notifier import SlackNotifierConfig
         ("GUARDDUTY_RUNBOOK_URL", Config().get_guardduty_runbook_url),
         ("VPC_AUDIT_REPORT_KEY", Config().get_vpc_audit_report_key),
         ("VPC_PEERING_AUDIT_REPORT_KEY", Config().get_vpc_peering_audit_report_key),
+        ("IGNORABLE_REPORT_KEYS", Config().get_ignorable_report_keys),
         ("PASSWORD_POLICY_AUDIT_REPORT_KEY", Config().get_password_policy_audit_report_key),
         ("SLACK_API_URL", Config().get_slack_api_url),
         ("SLACK_USERNAME_KEY", Config().get_slack_username_key),
@@ -66,6 +67,12 @@ def test_get_unsupported_log_level(monkeypatch: Any) -> None:
 
     assert "LOG_LEVEL" in str(ice)
     assert "banana" in str(ice)
+
+
+def test_get_ignorable_report_keys(monkeypatch: Any) -> None:
+    monkeypatch.setenv("IGNORABLE_REPORT_KEYS", "key_1.json,key_2.json")
+
+    assert Config().get_ignorable_report_keys() == ["key_1.json", "key_2.json"]
 
 
 @patch("src.clients.aws_client_factory.AwsClientFactory.get_ssm_client")

--- a/tests/test_audit_analyser.py
+++ b/tests/test_audit_analyser.py
@@ -28,6 +28,11 @@ from tests.test_types_generator import findings
 @patch.object(Config, "get_vpc_peering_audit_report_key", return_value="audit_vpc_peering.json")
 @patch.object(Config, "get_ec2_audit_report_key", return_value="audit_ec2.json")
 @patch.object(Config, "get_vpc_resolver_audit_report_key", return_value="audit_vpc_resolver_logs.json")
+@patch.object(
+    Config,
+    "get_ignorable_report_keys",
+    return_value=["a_unsupported_but_ignored_key.json", "a_unsupported_but_ignored_key_2.json"],
+)
 class TestAuditAnalyser(TestCase):
     def test_check_s3_compliance(self, *_: Mock) -> None:
         logger = getLogger()
@@ -114,6 +119,10 @@ class TestAuditAnalyser(TestCase):
     def test_check_unsupported_audit(self, *_: Mock) -> None:
         with self.assertRaisesRegex(UnsupportedAuditException, "wat"):
             AuditAnalyser().analyse(getLogger(), Audit(type="wat", report=[]), Config())
+
+    def test_check_unsupported_audit_can_ignore_keys(self, *_: Mock) -> None:
+        audit = Audit(type="a_unsupported_but_ignored_key.json", report=[{"report": "val-1"}, {"report": "val-2"}])
+        self.assertEqual(set(), AuditAnalyser().analyse(getLogger(), audit, Config()))
 
     def test_check_vpc_resolver_compliance(self, *_: Mock) -> None:
         logger = getLogger()


### PR DESCRIPTION
This makes reports that have no action not error (and therefore not create PD alerts). By explicitly adding them to the env var we can still find problems with mismatched report names