### PR TITLE
PSEC-1933-update-slack-message

### DIFF
--- a/src/sns/grant_user_access_lambda.py
+++ b/src/sns/grant_user_access_lambda.py
@@ -11,16 +11,15 @@ class GrantUserAccessLambda:
     def create_finding(message: Dict[str, Any]) -> Findings:
         account = Account(identifier=message["account"])
         region = message["region"]
-        grantor = message["grantor"]
         role_arn = message["roleArn"]
-        usernames = "\n".join(message["usernames"])
+        usernames = "\n  *  ".join(message["usernames"])
         hours = message["hours"]
         start_time = message["startTime"]
         end_time = message["endTime"]
         title = f"{role_arn} access granted"
         notification_text = (
-            f"Access to {role_arn} has been granted by {grantor} for {hours} hour(s) to "
-            f"the following users at {start_time}:\n{usernames}\n"
+            f"Access to `{role_arn}` has been granted for {hours} hour(s) to "
+            f"the following users at {start_time}:\n  *  {usernames}\n"
             f"Access expires at {end_time}."
         )
 

--- a/tests/resources/grant_user_access_lambda_event.json
+++ b/tests/resources/grant_user_access_lambda_event.json
@@ -8,7 +8,7 @@
         "Type": "Notification",
         "MessageId": "588f1e6a-ac82-55a6-8f99-44f29ce72019",
         "TopicArn": "arn:aws:sns:eu-west-2:123456789012:test-topic",
-        "Message": "{\"account\":\"123456789012\",\"detailType\":\"GrantUserAccessLambda\",\"roleArn\":\"arn:aws:iam::123456789012:role/RoleTestSSMAccess\",\"grantor\":\"approval.user\",\"region\":\"eu-west-2\",\"usernames\":[\"test-user01\",\"test-user02\"],\"hours\":\"1\",\"startTime\":\"2023-09-14T13:09:38Z\",\"endTime\":\"2023-09-14T14:09:38Z\"}",
+        "Message": "{\"account\":\"123456789012\",\"detailType\":\"GrantUserAccessLambda\",\"roleArn\":\"arn:aws:iam::123456789012:role/RoleTestSSMAccess\",\"region\":\"eu-west-2\",\"usernames\":[\"test-user01\",\"test-user02\"],\"hours\":\"1\",\"startTime\":\"2023-09-14T13:09:38Z\",\"endTime\":\"2023-09-14T14:09:38Z\"}",
         "Timestamp": "2022-03-01T14:31:01.784Z",
         "SignatureVersion": "1",
         "Signature": "JVYfudYVUZePeqO/Uq5cG3SHFyjoblcQ0aqfqxLTEaoHOqNX4NmN0oe+trJTu/aqzZtraIlH9rMaDohMm25dbBw/e04yfduQFBO+vf1DzaNSi4mRiPPygG79azP3+rjlkly068olh5YVs7amXwsR38xBSqIiM8ofjhxG6LnO+ai7UeqPdcUt3pqVhkfa9PIRwyjSM6pgURl2LBI3iY8xKrKDHsAFU1t4y3jyBuMQOX+OCYJaHh57s9bom6dsGdY+hzuXq764Z+NGr7UhjReMk/JJTg+/PzrAZD8p0TXve8OGgm4F7ohZLfvNYBKobEaZqoXpZrZd7RTxplRreNSRkQ==",

--- a/tests/sns/test_grant_user_access_lambda.py
+++ b/tests/sns/test_grant_user_access_lambda.py
@@ -16,8 +16,8 @@ def test_event_to_findings() -> None:
     assert len(finding.findings) == 1
 
     expected_notification_text = (
-        "Access to arn:aws:iam::123456789012:role/RoleTestSSMAccess has been granted by approval.user "
-        "for 1 hour(s) to the following users at 2023-09-14T13:09:38Z:\ntest-user01\ntest-user02\n"
+        "Access to `arn:aws:iam::123456789012:role/RoleTestSSMAccess` has been granted "
+        "for 1 hour(s) to the following users at 2023-09-14T13:09:38Z:\n  *  test-user01\n  *  test-user02\n"
         "Access expires at 2023-09-14T14:09:38Z."
     )
     assert finding.findings == frozenset({expected_notification_text})


### PR DESCRIPTION
Remove 'grantor' info from slack message

**Why?**
'grantor' field was meant to surface which PlatformOwner invoked this lambda.
However, it is not straightforward to get this info since lambda context doesn't
contain any info on who invoked the lambda. The alternative involves sourcing this
information from cloudtrail, which is quite involved. 
The same information can be found by checking which PO assumed the RolePlatformOwner role
when the lambda was invoked.
