### PR TITLE
PSEC-1933-update-slack-message

### DIFF
--- a/src/sns/grant_user_access_lambda.py
+++ b/src/sns/grant_user_access_lambda.py
@@ -16,7 +16,7 @@ class GrantUserAccessLambda:
         hours = message["hours"]
         start_time = message["startTime"]
         end_time = message["endTime"]
-        title = f"{role_arn} access granted"
+        title = f"`{role_arn}` access granted"
         notification_text = (
             f"Access to `{role_arn}` has been granted for {hours} hour(s) to "
             f"the following users at {start_time}:\n  *  {usernames}\n"

--- a/tests/sns/test_grant_user_access_lambda.py
+++ b/tests/sns/test_grant_user_access_lambda.py
@@ -12,7 +12,7 @@ def test_event_to_findings() -> None:
     assert finding.account
     assert finding.account.identifier == "123456789012"
     assert finding.compliance_item_type == "grant_user_access_lambda"
-    assert finding.item == "arn:aws:iam::123456789012:role/RoleTestSSMAccess access granted"
+    assert finding.item == "`arn:aws:iam::123456789012:role/RoleTestSSMAccess` access granted"
     assert len(finding.findings) == 1
 
     expected_notification_text = (


### PR DESCRIPTION
Remove 'grantor' info from slack message

**Why?**
'grantor' field was meant to surface which PlatformOwner invoked this lambda.
However, it is not straightforward to get this info since lambda context doesn't
contain any info on who invoked the lambda. The alternative involves sourcing this
information from cloudtrail, which is quite involved. 
The same information can be found by checking which PO assumed the RolePlatformOwner role
when the lambda was invoked.
