### PR TITLE
PSEC-1953-ssm-audit

### DIFF
--- a/src/audit_analyser.py
+++ b/src/audit_analyser.py
@@ -9,6 +9,7 @@ from src.compliance.iam_compliance import IamCompliance
 from src.compliance.s3_compliance import S3Compliance
 from src.compliance.github_compliance import GithubCompliance
 from src.compliance.github_webhook_compliance import GithubWebhookCompliance
+from src.compliance.ssm_compliance import SSMCompliance
 from src.compliance.vpc_peering_compliance import VpcPeeringCompliance
 from src.config.config import Config
 from src.data.audit import Audit
@@ -48,4 +49,5 @@ class AuditAnalyser:
             config.get_public_query_audit_report_key(): ActionableReportCompliance(
                 logger, "public_query_log", "public query log"
             ),
+            config.get_ssm_audit_report_key(): SSMCompliance(logger),
         }

--- a/src/compliance/ssm_compliance.py
+++ b/src/compliance/ssm_compliance.py
@@ -4,18 +4,16 @@ from src.data.account import Account
 
 from src.data.audit import Audit
 from src.data.findings import Findings
-from src.compliance.actionable_report_compliance import DetailedActionableReportCompliance
 from src.compliance.analyser import Analyser
 
 
 class SSMCompliance(Analyser):
-
     def __init__(self, logger: Logger):
         self.item_type = "ssm_document"
         super().__init__(logger, item_type=self.item_type)
 
     def analyse(self, audit: Audit) -> Set[Findings]:
-        findings: Findings = set()
+        findings = set()
         for sub_report in audit.report:
             for document in sub_report["results"]["documents"]:
                 if not document["compliant"]:
@@ -26,7 +24,7 @@ class SSMCompliance(Analyser):
                             region_name=sub_report["region"],
                             item=document["name"],
                             findings={f"compliant: {document['compliant']}"},
-                            description=f"SSM Document {document['name']} does not match the expected config", 
+                            description=f"SSM Document {document['name']} does not match the expected config",
                         )
                     )
         return findings

--- a/src/compliance/ssm_compliance.py
+++ b/src/compliance/ssm_compliance.py
@@ -1,0 +1,32 @@
+from logging import Logger
+from typing import Set
+from src.data.account import Account
+
+from src.data.audit import Audit
+from src.data.findings import Findings
+from src.compliance.actionable_report_compliance import DetailedActionableReportCompliance
+from src.compliance.analyser import Analyser
+
+
+class SSMCompliance(Analyser):
+
+    def __init__(self, logger: Logger):
+        self.item_type = "ssm_document"
+        super().__init__(logger, item_type=self.item_type)
+
+    def analyse(self, audit: Audit) -> Set[Findings]:
+        findings: Findings = set()
+        for sub_report in audit.report:
+            for document in sub_report["results"]["documents"]:
+                if not document["compliant"]:
+                    findings.add(
+                        Findings(
+                            compliance_item_type=self.item_type,
+                            account=Account.from_dict(sub_report["account"]),
+                            region_name=sub_report["region"],
+                            item=document["name"],
+                            findings={f"compliant: {document['compliant']}"},
+                            description=f"SSM Document {document['name']} does not match the expected config", 
+                        )
+                    )
+        return findings

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -113,6 +113,10 @@ class Config:
         return self._get_env("IGNORABLE_REPORT_KEYS").split(",")
 
     @classmethod
+    def get_ssm_audit_report_key(self) -> str:
+        return self._get_env("SSM_AUDIT_REPORT_KEY")
+
+    @classmethod
     def get_slack_api_url(self) -> str:
         return self._get_env("SLACK_API_URL")
 

--- a/tests/compliance/test_ssm_compliance.py
+++ b/tests/compliance/test_ssm_compliance.py
@@ -1,0 +1,22 @@
+from logging import getLogger
+from src.compliance.ssm_compliance import SSMCompliance
+
+from tests.fixtures.ssm_compliance import ssm_audit_report
+from tests.test_types_generator import account, create_audit, findings
+
+
+acc_1 = account("111222333444", "account-1")
+acc_2 = account("787878787878", "account-2")
+
+finding_1 = findings(
+    account=acc_1,
+    compliance_item_type="ssm_document",
+    item="SSM-SessionManagerRunShell",
+    findings={"compliant: False"},
+    description="SSM Document SSM-SessionManagerRunShell does not match the expected config",
+)
+
+
+def test_analyse_ssm_document_audit() -> None:
+    audit = create_audit(type="audit_ssm_document.json", report=ssm_audit_report)
+    assert SSMCompliance(getLogger()).analyse(audit) == {finding_1}

--- a/tests/fixtures/ssm_compliance.py
+++ b/tests/fixtures/ssm_compliance.py
@@ -1,0 +1,18 @@
+ssm_audit_report = [
+  {
+    "account": {
+        "identifier": "111222333444",
+        "name": "account-1"
+    },
+    "region": "test-region-name",
+    "description": "Audit SSM RunShell Document",
+    "results": {
+      "documents": [
+        {
+          "name": "SSM-SessionManagerRunShell",
+          "compliant": False
+        }
+      ]
+    }
+  }
+]

--- a/tests/fixtures/ssm_compliance.py
+++ b/tests/fixtures/ssm_compliance.py
@@ -1,18 +1,8 @@
 ssm_audit_report = [
-  {
-    "account": {
-        "identifier": "111222333444",
-        "name": "account-1"
-    },
-    "region": "test-region-name",
-    "description": "Audit SSM RunShell Document",
-    "results": {
-      "documents": [
-        {
-          "name": "SSM-SessionManagerRunShell",
-          "compliant": False
-        }
-      ]
+    {
+        "account": {"identifier": "111222333444", "name": "account-1"},
+        "region": "test-region-name",
+        "description": "Audit SSM RunShell Document",
+        "results": {"documents": [{"name": "SSM-SessionManagerRunShell", "compliant": False}]},
     }
-  }
 ]

--- a/tests/test_audit_analyser.py
+++ b/tests/test_audit_analyser.py
@@ -36,6 +36,7 @@ MOCK_CLIENTS = {
 @patch.object(Config, "get_vpc_resolver_audit_report_key", return_value="audit_vpc_resolver_logs.json")
 @patch.object(Config, "get_public_query_audit_report_key", return_value="audit_route53_query_logs.json")
 @patch.object(Config, "get_enable_wiki_checking", return_value=True)
+@patch.object(Config, "get_ssm_audit_report_key", return_value="audit_ssm_document.json")
 @patch.object(
     Config,
     "get_ignorable_report_keys",

--- a/tests/test_compliance_alerter.py
+++ b/tests/test_compliance_alerter.py
@@ -29,6 +29,7 @@ from tests.fixtures.s3_compliance_alerter import s3_report
 from tests.fixtures.vpc_compliance import vpc_report
 from tests.fixtures.vpc_peering_compliance import vpc_peering_audit
 from tests.fixtures.password_policy_compliance import password_policy_report
+from tests.fixtures.ssm_compliance import ssm_audit_report
 
 CHANNEL = "the-alerting-channel"
 CONFIG_BUCKET = "the_config_bucket"
@@ -42,6 +43,7 @@ VPC_KEY = "vpc_audit"
 VPC_PEERING_KEY = "vpc_peering_audit"
 PUBLIC_QUERY_KEY = "public_query_audit"
 EC2_KEY = "ec2_audit"
+SSM_AUDIT_REPORT_KEY = "ssm_audit"
 PASSWORD_POLICY_KEY = "password_policy_audit"
 SLACK_API_URL = "https://the-slack-api-url.com"
 SLACK_USERNAME_KEY = "the-slack-username-key"
@@ -368,6 +370,7 @@ def _setup_environment(monkeypatch: Any) -> None:
         "PUBLIC_QUERY_AUDIT_REPORT_KEY": PUBLIC_QUERY_KEY,
         "VPC_PEERING_AUDIT_REPORT_KEY": VPC_PEERING_KEY,
         "EC2_AUDIT_REPORT_KEY": EC2_KEY,
+        "SSM_AUDIT_REPORT_KEY": SSM_AUDIT_REPORT_KEY,
         "LOG_LEVEL": "DEBUG",
         "ORG_ACCOUNT": "ORG-ACCOUNT-ID-12374234",
         "ORG_READ_ROLE": "the-org-read-role",
@@ -503,6 +506,7 @@ def setup_report_bucket(s3_client: BaseClient, account_id: str) -> BaseClient:
     )
     s3_client.put_object(Bucket=REPORT_BUCKET, Key=GITHUB_KEY, Body=json.dumps(github_report))
     s3_client.put_object(Bucket=REPORT_BUCKET, Key=GITHUB_WEBHOOK_KEY, Body=json.dumps(github_webhook_report))
+    s3_client.put_object(Bucket=REPORT_BUCKET, Key=SSM_AUDIT_REPORT_KEY, Body=json.dumps(ssm_audit_report))
     return s3_client
 
 


### PR DESCRIPTION
Support for analysing SSM audit report

**WHY**
A new audit report on SSM document compliance is generated by platsec-aws-scanner
.
  With this change this lambda can analyse and alert on non-compliant SSM document.