### PR TITLE
PSEC-2096 updating code to authenticate with mdtp Slack V2 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,7 @@ This Python program is meant to run as an AWS Lambda function that requires the 
 - `GITHUB_AUDIT_REPORT_KEY`: name of audit reports that should trigger a Github compliance check
 - `GITHUB_WEBHOOK_REPORT_KEY`: name of webhook reports that should trigger a Github webhook compliance check
 - `SLACK_API_URL`: PlatApps Slack API URL
-- `SLACK_USERNAME_KEY`: name of the SSM parameter that contains PlatApps Slack API username
-- `SLACK_TOKEN_KEY`: name of the SSM parameter that contains PlatApps Slack API token
+- `SLACK_V2_API_KEY`: name of the SSM parameter that contains PlatApps Slack v2 endpoint API key
 - `SSM_READ_ROLE`: name of an IAM role that can read SSM parameters
 - `VPC_AUDIT_REPORT_KEY`: name of audit reports that should trigger a VPC compliance check
 

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -121,12 +121,8 @@ class Config:
         return self._get_env("SLACK_API_URL")
 
     @classmethod
-    def get_slack_username_key(self) -> str:
-        return self._get_env("SLACK_USERNAME_KEY")
-
-    @classmethod
-    def get_slack_token_key(self) -> str:
-        return self._get_env("SLACK_TOKEN_KEY")
+    def get_slack_v2_api_key(self) -> str:
+        return self._get_env("SLACK_V2_API_KEY")
 
     @classmethod
     def get_ssm_read_role(self) -> str:
@@ -142,8 +138,7 @@ class Config:
 
     def get_slack_notifier_config(self) -> SlackNotifierConfig:
         return SlackNotifierConfig(
-            username=self.ssm_client.get_parameter(self.get_slack_username_key()),
-            token=self.ssm_client.get_parameter(self.get_slack_token_key()),
+            api_v2_key=self.ssm_client.get_parameter(self.get_slack_v2_api_key()),
             api_url=self.get_slack_api_url(),
         )
 

--- a/src/config/slack_notifier_config.py
+++ b/src/config/slack_notifier_config.py
@@ -3,6 +3,5 @@ from dataclasses import dataclass
 
 @dataclass
 class SlackNotifierConfig:
-    username: str
-    token: str
+    api_v2_key: str
     api_url: str

--- a/src/notifiers/slack_notifier.py
+++ b/src/notifiers/slack_notifier.py
@@ -55,10 +55,8 @@ class SlackNotifier(Notifier[SlackMessage, Finding]):
         return dict(response.json())
 
     def _build_headers(self) -> Dict[str, str]:
-        credentials = b64encode(
-            f"{self._notifier_config.username}:{self._notifier_config.token}".encode("utf-8")
-        ).decode("utf-8")
-        return {"Content-Type": "application/json", "Authorization": f"Basic {credentials}"}
+        credentials = b64encode(f"{self._notifier_config.api_v2_key}".encode("utf-8")).decode("utf-8")
+        return {"Content-Type": "application/json", "Authorization": f"{credentials}"}
 
     def apply_filters(self, findings: Set[Finding]) -> Set[Finding]:
         return FindingsFilter().do_filter(findings, self._filters_config)

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -42,8 +42,7 @@ MOCK_CLIENTS: Dict[str, Any] = {
         ("PUBLIC_QUERY_AUDIT_REPORT_KEY", Config(**MOCK_CLIENTS).get_public_query_audit_report_key),
         ("PASSWORD_POLICY_AUDIT_REPORT_KEY", Config(**MOCK_CLIENTS).get_password_policy_audit_report_key),
         ("SLACK_API_URL", Config(**MOCK_CLIENTS).get_slack_api_url),
-        ("SLACK_USERNAME_KEY", Config(**MOCK_CLIENTS).get_slack_username_key),
-        ("SLACK_TOKEN_KEY", Config(**MOCK_CLIENTS).get_slack_token_key),
+        ("SLACK_V2_API_KEY", Config(**MOCK_CLIENTS).get_slack_v2_api_key),
         ("SSM_READ_ROLE", Config(**MOCK_CLIENTS).get_ssm_read_role),
         ("ORG_ACCOUNT", Config(**MOCK_CLIENTS).get_org_account),
         ("ORG_READ_ROLE", Config(**MOCK_CLIENTS).get_org_read_role),
@@ -120,16 +119,14 @@ def test_get_ignorable_report_keys(monkeypatch: Any) -> None:
 
 def test_get_slack_notifier_config(monkeypatch: Any) -> None:
     monkeypatch.setenv("SLACK_API_URL", "the-url")
-    monkeypatch.setenv("SLACK_USERNAME_KEY", "username-key")
-    monkeypatch.setenv("SLACK_TOKEN_KEY", "token-key")
+    monkeypatch.setenv("SLACK_V2_API_KEY", "some-test-api-v2-key")
     ssm_client = Mock().return_value
     ssm_client.get_parameter.side_effect = lambda x: {
-        "username-key": "the-user",
-        "token-key": "the-token",
+        "some-test-api-v2-key": "some-test-api-v2-key",
     }[x]
     MOCK_CLIENTS["ssm_client"] = ssm_client
 
-    assert SlackNotifierConfig("the-user", "the-token", "the-url") == Config(**MOCK_CLIENTS).get_slack_notifier_config()
+    assert SlackNotifierConfig("some-test-api-v2-key", "the-url") == Config(**MOCK_CLIENTS).get_slack_notifier_config()
 
 
 @patch("src.config.config.Config._fetch_config_files")

--- a/tests/notifiers/test_slack_notifier.py
+++ b/tests/notifiers/test_slack_notifier.py
@@ -15,21 +15,20 @@ from src.notifiers.slack_notifier import SlackNotifier
 
 TEST_COLOUR = "some-colour"
 SLACK_MESSAGE = SlackMessage(["channel-a", "channel-b"], "a-header", "a-title", "a-text", "#c1e7c6")
-API_URL = "https://fake-api-url.com/"
-USER = "user"
-USER_PASS = "token"
-BASIC_AUTH = base64.b64encode(f"{USER}:{USER_PASS}".encode("utf-8")).decode("utf-8")
+TEST_SLACK_API_URL = "https://fake-api-url.com/"
+API_V2_KEY = "testapiv2key"
+AUTH = base64.b64encode(f"{API_V2_KEY}".encode("utf-8")).decode("utf-8")
 
 
 def _create_slack_notifier() -> SlackNotifier:
-    slack_notifier_config = SlackNotifierConfig(USER, USER_PASS, API_URL)
+    slack_notifier_config = SlackNotifierConfig(API_V2_KEY, TEST_SLACK_API_URL)
     return SlackNotifier(Mock(get_slack_notifier_config=Mock(return_value=slack_notifier_config)))
 
 
 def _register_slack_api_success() -> None:
     httpretty.register_uri(
         httpretty.POST,
-        API_URL,
+        TEST_SLACK_API_URL,
         body=json.dumps({"successfullySentTo": ["channel-a", "channel-b"]}),
         status=200,
     )
@@ -38,7 +37,7 @@ def _register_slack_api_success() -> None:
 def _register_slack_api_failure(status: int) -> None:
     httpretty.register_uri(
         httpretty.POST,
-        API_URL,
+        TEST_SLACK_API_URL,
         body=json.dumps({"errors": [{"code": "error", "message": "statusCode: 404, msg: 'channel_not_found'"}]}),
         status=status,
     )
@@ -47,7 +46,7 @@ def _register_slack_api_failure(status: int) -> None:
 def _assert_headers_correct() -> None:
     headers = httpretty.last_request().headers.items()
     assert ("Content-Type", "application/json") in headers
-    assert ("Authorization", f"Basic {BASIC_AUTH}") in headers  # base64 of "user:token"
+    assert ("Authorization", f"{AUTH}") in headers  # base64 of "user:token"
 
 
 def _assert_payload_correct() -> None:

--- a/tests/test_compliance_alerter.py
+++ b/tests/test_compliance_alerter.py
@@ -50,8 +50,7 @@ EC2_KEY = "ec2_audit"
 SSM_AUDIT_REPORT_KEY = "ssm_audit"
 PASSWORD_POLICY_KEY = "password_policy_audit"
 SLACK_API_URL = "https://the-slack-api-url.com"
-SLACK_USERNAME_KEY = "the-slack-username-key"
-SLACK_TOKEN_KEY = "the-slack-token-key"
+SLACK_V2_API_KEY = "the-slack-v2-api-key"
 PAGERDUTY_SERVICE = "the-pagerduty-service"
 PAGERDUTY_API_URL = "https://the-pagerduty-api-url.com"
 PAGERDUTY_SERVICE_ROUTING_KEY = f"{PAGERDUTY_SERVICE}-routing-key"
@@ -505,8 +504,7 @@ def _setup_environment(monkeypatch: Any) -> None:
         "GUARDDUTY_RUNBOOK_URL": "the-gd-runbook",
         "PASSWORD_POLICY_AUDIT_REPORT_KEY": PASSWORD_POLICY_KEY,
         "SLACK_API_URL": SLACK_API_URL,
-        "SLACK_USERNAME_KEY": SLACK_USERNAME_KEY,
-        "SLACK_TOKEN_KEY": SLACK_TOKEN_KEY,
+        "SLACK_V2_API_KEY": SLACK_V2_API_KEY,
         "SSM_READ_ROLE": "the-ssm-read-role",
         "VPC_AUDIT_REPORT_KEY": VPC_KEY,
         "PUBLIC_QUERY_AUDIT_REPORT_KEY": PUBLIC_QUERY_KEY,
@@ -531,8 +529,7 @@ def _ssm_client() -> Iterator[BaseClient]:
 
 
 def _setup_ssm_parameters(ssm_client: BaseClient) -> BaseClient:
-    ssm_client.put_parameter(Name=SLACK_USERNAME_KEY, Value="the-slack-username", Type="SecureString")
-    ssm_client.put_parameter(Name=SLACK_TOKEN_KEY, Value="the-slack-username", Type="SecureString")
+    ssm_client.put_parameter(Name=SLACK_V2_API_KEY, Value="the-slack-v2-api-key", Type="SecureString")
     ssm_client.put_parameter(
         Name=f"{PAGERDUTY_SSM_PARAMETER_STORE_PREFIX}{PAGERDUTY_SERVICE}",
         Value=PAGERDUTY_SERVICE_ROUTING_KEY,


### PR DESCRIPTION
The code is updated to comply with authentication with MDTP Slack V2 endpoint as documented here: https://github.com/hmrc/slack-notifications 

SLACK_USERNAME_KEY and SLACK_TOKEN_KEY keys that are obtained from AWS Parameter Store per environment are now to replaced with SLACK_V2_API_KEY
